### PR TITLE
fix: adding missing inputfile to stop failing when not using notemp

### DIFF
--- a/workflow/rules/exomedepth_reference_set.smk
+++ b/workflow/rules/exomedepth_reference_set.smk
@@ -34,6 +34,8 @@ rule exomedepth_bam_list:
 rule exomedepth_reference:
     input:
         bam_list_file="references/exomedepth_bam_list/bam_files.list",
+        bam_files=get_bams(units),
+        bai_files=get_bais(units),
     output:
         reference="references/exomedepth_reference/RefCount.Rdata",
     params:

--- a/workflow/rules/msi_sensor_pro_panel_of_normal.smk
+++ b/workflow/rules/msi_sensor_pro_panel_of_normal.smk
@@ -61,6 +61,8 @@ rule msisensor_pro_input_file:
 rule msisensor_pro_baseline:
     input:
         bam_conf="references/msisensor_pro_input_file/configure.txt",
+        bam_files=get_bams(units),
+        bai_files=get_bais(units),
         PoN_list="references/msisensor_pro_scan/Msisensor_pro_reference.list",
     output:
         PoN_list=temp("references/msisensor_pro_baseline/Msisensor_pro_reference.list_baseline"),

--- a/workflow/rules/purecn_panel_of_normal.smk
+++ b/workflow/rules/purecn_panel_of_normal.smk
@@ -74,6 +74,8 @@ rule purecn_bam_list:
 rule purecn_coverage:
     input:
         bam_list_file="references/purecn_bam_list/bam_files.list",
+        bam_files=get_bams(units),
+        bai_files=get_bais(units),
     output:
         coverage_list=get_coverage_files(samples, units),
     params:
@@ -172,6 +174,7 @@ rule bcftools_merge:
 rule purecn_normal_db:
     input:
         coverage_list_file="references/purecn_coverage_list/coverage_files.list",
+        coverage_files=get_coverage_files(samples, units),
         normal_vcf="references/bcftools_merge/normal_db.vcf.gz",
         normal_vcf_tbi="references/bcftools_merge/normal_db.vcf.gz.tbi",
     output:


### PR DESCRIPTION
Some rules use filelist (e.g. `bam_file.list`) as input, when running it without `--notemp` flag the files in the lists might have been deleted before the rule can be executed.