### PR TITLE
fix: update input function in deepsomatic_pon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hydra-genetics>=3.3.2,<4.0.0
+hydra-genetics==4.0.0
 pandas>=1.3.1
 snakemake>=7.13.0,<8
 singularity==3.0.0

--- a/workflow/rules/deepsomatic.smk
+++ b/workflow/rules/deepsomatic.smk
@@ -6,8 +6,8 @@ __license__ = "GPL-3"
 
 rule deepsomatic_pon:
     input:
-        bam=lambda wildcards: get_input_aligned_bam(wildcards, config)[0],
-        bai=lambda wildcards: get_input_aligned_bam(wildcards, config)[1],
+        bam=lambda wildcards: get_input_aligned_bam(wildcards, config, set_type="N")[0],
+        bai=lambda wildcards: get_input_aligned_bam(wildcards, config, set_type="N")[1],
         ref=config.get("reference", {}).get("fasta", ""),
         bed=config.get("reference", {}).get("design_bed", ""),
     output:


### PR DESCRIPTION
### This PR:

Fixed: use set_type=N in get_input_aligned_bam; requires hydra-genetics v4.0.0

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
- [ ] Module compatibility section in `README.md` is up to date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded and pinned hydra-genetics framework dependency to version 4.0.0 to ensure consistent and stable behavior across all deployment environments

* **Bug Fixes**
  * Fixed normal sample input handling in the DeepSomatic analysis workflow pipeline to ensure correct processing of aligned BAM files and corresponding index files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->